### PR TITLE
Adding a git ignore for simpler code archiving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+payloads/*
+.idea/


### PR DESCRIPTION
- we archive and distribute code using `git archive` on the main/master branch. We don't want to include pre-compiled payloads in that archive, so we ignore the payloads dir 